### PR TITLE
fixed improper image scaling for non-square items

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -78,6 +78,8 @@ html {
 
 .preview__image {
     vertical-align: middle;
+    width: inherit;
+    height: inherit;
 }
 
 .navbar__items {


### PR DESCRIPTION
The item image was not being scaled to the size of its parent div
Solves issue #28 